### PR TITLE
Add configuration support for target service authority

### DIFF
--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -207,6 +207,7 @@ func (sb *SyncBuilder) newGRPC(config sync.SourceConfig, logger *logger.Logger) 
 		Secure:            config.TLS,
 		Selector:          config.Selector,
 		MaxMsgSize:        config.MaxMsgSize,
+		ServAuthority:     config.ServAuthority,
 	}
 }
 

--- a/core/pkg/sync/builder/syncbuilder_test.go
+++ b/core/pkg/sync/builder/syncbuilder_test.go
@@ -195,6 +195,27 @@ func Test_SyncsFromFromConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "grpc-with-service-authority",
+			args: args{
+				logger: lg,
+				sources: []sync.SourceConfig{
+					{
+						URI:        "grpc://host:port",
+						Provider:   syncProviderGrpc,
+						ProviderID: "myapp",
+						CertPath:   "/tmp/ca.cert",
+						Selector:   "source=database",
+						MaxMsgSize: 10,
+						ServAuthority: "target-service",
+					},
+				},
+			},
+			wantSyncs: []sync.ISync{
+				&grpc.Sync{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "combined",
 			injectFunc: func(builder *SyncBuilder) {
 				ctrl := gomock.NewController(t)

--- a/core/pkg/sync/isync.go
+++ b/core/pkg/sync/isync.go
@@ -66,12 +66,13 @@ type SourceConfig struct {
 	URI      string `json:"uri"`
 	Provider string `json:"provider"`
 
-	BearerToken string `json:"bearerToken,omitempty"`
-	AuthHeader  string `json:"authHeader,omitempty"`
-	CertPath    string `json:"certPath,omitempty"`
-	TLS         bool   `json:"tls,omitempty"`
-	ProviderID  string `json:"providerID,omitempty"`
-	Selector    string `json:"selector,omitempty"`
-	Interval    uint32 `json:"interval,omitempty"`
-	MaxMsgSize  int    `json:"maxMsgSize,omitempty"`
+	BearerToken 	  string `json:"bearerToken,omitempty"`
+	AuthHeader  	  string `json:"authHeader,omitempty"`
+	CertPath    	  string `json:"certPath,omitempty"`
+	TLS         	  bool   `json:"tls,omitempty"`
+	ProviderID  	  string `json:"providerID,omitempty"`
+	Selector    	  string `json:"selector,omitempty"`
+	Interval    	  uint32 `json:"interval,omitempty"`
+	MaxMsgSize  	  int    `json:"maxMsgSize,omitempty"`
+	ServAuthority     string `json:"servAuthority,omitempty"`
 }

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -40,6 +40,7 @@ Alternatively, these configurations can be passed to flagd via config file, spec
 | selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                                                                                          |
 | certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                                                         |
 | maxMsgSize  | optional `int`     | Used for gRPC sync to set max receive message size (in bytes) e.g. 5242880 for 5MB. If not provided, the default is [4MB](https://pkg.go.dev/google.golang.org#grpc#MaxCallRecvMsgSize)                       |
+| servAuthority | optional `string` | Specifies the target host (authority) when routing requests through a proxy (e.g., Envoy). If not provided, no authority header will be set                                                                   |
 
 The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
 from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect


### PR DESCRIPTION
## This PR
Adding a new config option that allows flagd clients to override the authority. This is useful when running gRPC sync service behind proxy e.g. envoy, istio etc. For more details, please refer this [PR](https://github.com/open-feature/java-sdk-contrib/pull/949) 

- adds this new feature

### Related Issues
https://github.com/open-feature/java-sdk-contrib/pull/949

### Notes


### Follow-up Tasks


### How to test


